### PR TITLE
Add short types: nullable_t and non_nullable_t

### DIFF
--- a/src/sql.ml
+++ b/src/sql.ml
@@ -19,3 +19,6 @@
 *)
 
 include Inner_sql
+
+type 'a nullable_t = < get : unit; t : 'a; nul : nullable > t
+type 'a non_nullable_t = < get : unit; t : 'a; nul : non_nullable > t

--- a/src/sql.mli
+++ b/src/sql.mli
@@ -59,6 +59,9 @@ type 't type_info_only = < t : 't type_info >
 type +'a t
 val untyped_t : 'a t -> untyped t
 
+type 'a nullable_t = < get : unit; t : 'a; nul : nullable > t
+type 'a non_nullable_t = < get : unit; t : 'a; nul : non_nullable > t
+
 type 'phant binary_op = 'a t -> 'b t -> 'c t
 constraint 'a = < t : 'in_t; nul : 'n; .. >
 constraint 'b = < t : 'in_t; nul : 'n; .. >


### PR DESCRIPTION
As discussed before, here is my contribution. I've modified a little the type which is now two types: one for nullable and the other for non_nullable.

You can see the use case here: https://bitbucket.org/Engil/cumulus/src/d862fcac45f987c798a039dfc64a0c969c8caa7f/src/db_user.mli?at=master

I think it's more clear and short than having an object in an other object.
