### PR TITLE
current_timestamp now using timestamptz + adding localtimestamp for time...

### DIFF
--- a/src/sql.mli
+++ b/src/sql.mli
@@ -331,7 +331,8 @@ module Op : sig
   val currval : 'a sequence -> < t : 'a; nul : non_nullable > t
 
   (** timestamp *)
-  val current_timestamp : < t : timestamp_t; nul : _ > t
+  val current_timestamp : < t : timestamptz_t; nul : _ > t
+  val localtimestamp : < t : timestamp_t; nul : _ > t
 end
 
 (** standard view injections

--- a/src/sql_public.ml
+++ b/src/sql_public.ml
@@ -120,7 +120,10 @@ module Op = struct
     prefixop "currval" (label seq_name), Non_nullable typ
 
   let current_timestamp =
-    Op ([], "current_timestamp", []), Non_nullable TTimestamp
+    Op ([], "current_timestamp", []), Non_nullable TTimestamptz
+
+  let localtimestamp =
+    Op ([], "localtimestamp", []), Non_nullable TTimestamp
 end
 
 module Table_type = struct


### PR DESCRIPTION
Hello!
If I'm right current_timestamp returns a timestamptz, not a timestamp.
Can you check?
Here a patach changing this and adding localtimestamp for timestamp.
Vincent
