### PR TITLE
support unary operators (BREAKING CHANGE)

### DIFF
--- a/README
+++ b/README
@@ -144,6 +144,11 @@ Examples :
     <:value< 1 = 1 >>
 
 
+- the current timestamp (with local timezone information, use
+  `localtimestamp` to omit it):
+
+    <:value< current_timestamp () >>
+
 - field 'id' of table 'foo', casted as a nullable value (wich can take the `NULL` value)
 
     <:value< nullable foo.id >>
@@ -281,7 +286,7 @@ For this purpose, Macaque was extended with:
 
 As an example, the following three definitions of `get_time` are equivalent:
 
-  let time = <:value< current_timestamp >>
+  let time = <:value< current_timestamp () >>
 
   let get_time dbh =
     Sql.get (Query.view_one dbh <:view< {x = $time$} >>)#x

--- a/src/pa_macaque.ml
+++ b/src/pa_macaque.ml
@@ -209,8 +209,6 @@ let () =
 
   let operation _loc op operands = (_loc, Op ((_loc, op), operands)) in
 
-  let unary _loc op = (_loc, Op ((_loc, Ident op), [])) in
-
   let opt_list _loc = function
     | None -> (_loc, [])
     | Some thing -> thing in
@@ -357,10 +355,9 @@ let () =
      | "simple"
          [ v = atom -> (_loc, Atom v)
          | (_, tup) = tuple -> (_loc, Tuple tup)
-         | LIDENT "null" -> unary _loc "null"
-         | LIDENT "current_timestamp" -> unary _loc "current_timestamp"
+         | LIDENT "null" -> operation _loc (Ident "null") []
          | id = sql_ident -> (_loc, Ident id)
-         | "("; (_, e) = SELF; ")" -> (_loc, e)
+         | TRY "("; (_, e) = SELF; ")" -> (_loc, e)
          | "["; e = SELF; "]" -> (_loc, Accum e) ]];
 
    sql_type: [[ typ = LIDENT -> (_loc, typ) ]];
@@ -398,6 +395,7 @@ let () =
           | `FLOAT(f, _) -> <:expr< Sql.Value.float $`flo:f$ >>
           | "true" -> <:expr< Sql.Value.bool True >>
           | "false" -> <:expr< Sql.Value.bool False >>
+          | "("; ")" -> <:expr< Sql.Value.unit () >>
           | `ANTIQUOT(id, v) ->
               <:expr< Sql.Value.$lid:id$ $quote _loc v$ >> ]];
  END;

--- a/src/sql.mli
+++ b/src/sql.mli
@@ -36,6 +36,7 @@ val non_nullable_witness : non_nullable nul_witness
 class type ['t] type_info = object method typ : 't end
 class type numeric_t = object method numeric : unit end
 
+class type unit_t = object inherit [unit] type_info end
 class type bool_t = object inherit [bool] type_info end
 class type int16_t = object inherit [int16] type_info inherit numeric_t end
 class type int32_t = object inherit [int32] type_info inherit numeric_t end
@@ -241,6 +242,7 @@ val handle_query_results : 'a query -> string array list unsafe -> 'a
 (** standard SQL value injections
     (usable from user code, in pa_macaque value antiquotations) *)
 module Value : sig
+  val unit : unit -> < t : unit_t; nul : _ > t
   val bool : bool -> < t : bool_t; nul : _ > t
   val int16 : int16 -> < t : int16_t; nul : _ > t
   val int32 : int32 -> < t : int32_t; nul : _ > t
@@ -331,8 +333,8 @@ module Op : sig
   val currval : 'a sequence -> < t : 'a; nul : non_nullable > t
 
   (** timestamp *)
-  val current_timestamp : < t : timestamptz_t; nul : _ > t
-  val localtimestamp : < t : timestamp_t; nul : _ > t
+  val current_timestamp : < t : unit_t; .. > t -> < t : timestamptz_t; nul : _ > t
+  val localtimestamp : < t : unit_t; .. > t -> < t : timestamp_t; nul : _ > t
 end
 
 (** standard view injections

--- a/src/sql_builders.ml
+++ b/src/sql_builders.ml
@@ -4,7 +4,7 @@ open Sql_types
 (** operations *)
 let null_workaround (v, t) =
   (* NULL WORKAROUND
-     
+
      It is assumed that any value with type Nullable None is NULL.
      This can work around several PostGreSQL Typing limitations
      wrt. NULL, such as the (NULL + NULL) issue or, worse :
@@ -12,6 +12,9 @@ let null_workaround (v, t) =
   *)
   if is_null_type t then null
   else (v, t)
+
+let check_atom_type ty atom_t =
+  ignore (unify ty (Non_nullable atom_t))
 
 let fixed_op op a b return_t =
   let input_t = unify (get_type a) (get_type b) in

--- a/src/sql_parsers.ml
+++ b/src/sql_parsers.ml
@@ -19,6 +19,8 @@ let unsafe_record_parser record_parser : untyped record_parser =
 
 let pack atom atom_type : value = Atom atom, Non_nullable atom_type
 
+let unitval_of_string s =
+  pack (Unit (PGOCaml.unit_of_string s)) TBool
 let boolval_of_string s =
   pack (Bool (PGOCaml.bool_of_string s)) TBool
 let int16val_of_string s =
@@ -46,6 +48,7 @@ let intervalval_of_string s =
 let int32_array_of_string s =
   pack (Int32_array (PGOCaml.int32_array_of_string s)) TInt32_array
 
+let unit_field_parser = unsafe_parser (incr &&& unitval_of_string)
 let bool_field_parser = unsafe_parser (incr &&& boolval_of_string)
 let int16_field_parser = unsafe_parser (incr &&& int16val_of_string)
 let int32_field_parser = unsafe_parser (incr &&& int32val_of_string)
@@ -85,6 +88,7 @@ let record_parser t =
 
 let parser_of_type =
   let parser_of_sql_type = function
+    | TUnit -> unit_field_parser
     | TBool -> bool_field_parser
     | TInt16 -> int16_field_parser
     | TInt32 -> int32_field_parser

--- a/src/sql_printers.ml
+++ b/src/sql_printers.ml
@@ -156,6 +156,7 @@ and string_of_table_name = function
 and string_of_atom =
   let quote printer value = sprintf "E'%s'" (printer value) in
   function
+    | Unit u -> PGOCaml.string_of_unit u
     | Bool b -> macaque_string_of_bool b
     | Int16 i -> PGOCaml.string_of_int16 i
     | Int32 i -> PGOCaml.string_of_int32 i

--- a/src/sql_public.ml
+++ b/src/sql_public.ml
@@ -30,6 +30,7 @@ let parse ty =
     (Sql_parsers.parser_of_type ty)
 
 module Value = struct
+  let unit () = Atom (Unit ()), Non_nullable TUnit
   let bool b = Atom (Bool b), Non_nullable TBool
   let int16 i = Atom (Int16 i), Non_nullable TInt16
   let int32 i = Atom (Int32 i), Non_nullable TInt32
@@ -119,10 +120,12 @@ module Op = struct
   let currval (seq_name, typ) =
     prefixop "currval" (label seq_name), Non_nullable typ
 
-  let current_timestamp =
+  let current_timestamp u =
+    check_atom_type (get_type u) TUnit;
     Op ([], "current_timestamp", []), Non_nullable TTimestamptz
 
-  let localtimestamp =
+  let localtimestamp u =
+    check_atom_type (get_type u) TUnit;
     Op ([], "localtimestamp", []), Non_nullable TTimestamp
 end
 

--- a/src/sql_types.ml
+++ b/src/sql_types.ml
@@ -30,6 +30,7 @@ type non_nullable
 class type ['t] type_info = object method typ : 't end
 class type numeric_t = object method numeric : unit end
 
+class type unit_t = object inherit [unit] type_info end
 class type bool_t = object inherit [bool] type_info end
 class type int16_t = object inherit [int16] type_info inherit numeric_t end
 class type int32_t = object inherit [int32] type_info inherit numeric_t end
@@ -95,6 +96,7 @@ let get_val : < get : _; t : 'a #type_info; .. > atom -> 'a =
   let (!?) = Obj.magic in
   (* the magic is correct by type safety of 'a t *)
   function
+    | SQLI.Unit u -> !?u
     | SQLI.Bool b -> !?b
     | SQLI.Int16 i -> !?i
     | SQLI.Int32 i -> !?i

--- a/src/tests/ops.ml
+++ b/src/tests/ops.ml
@@ -42,6 +42,8 @@ let () =
   test "null IS NOT DISTINCT FROM null"
     string_of_bool <:value< is_not_distinct_from null null >>;
   test "current_timestamp"
-    PGOCaml.string_of_timestamp <:value< current_timestamp >>;
+    PGOCaml.string_of_timestamptz <:value< current_timestamp () >>;
+  test "localtimestamp"
+    PGOCaml.string_of_timestamp <:value< localtimestamp () >>;
   test_opt "NULL" string_of_bool <:value< null >>;
   ()

--- a/src/tests/union.ml
+++ b/src/tests/union.ml
@@ -55,6 +55,12 @@ let () =
   test_size "bugfix3" 2
     (* fix https://github.com/ocsigen/macaque/issues/14 *)
     << union (union ({x= cast null as integer}) ({x=null})) ({x=1}) >>;
+  test_size "bugfix4" 2
+    (* fix https://github.com/ocsigen/macaque/issues/12 *)
+  << union
+       ({ foo = 1; bar = "test"} | 1 = 1)
+       ({ bar = "test"; foo = 1} | 1 = 1)
+  >>;
   clear dbh test1;
   clear dbh test2;
   ()


### PR DESCRIPTION
<:value< current_timestamp >> was previously special-cased in the
grammar to expand to Sql.Op.current_timestamp, while other identifiers
were interpreted as row names. I removed this special case and added
a `unit` value in SQL-land, so you can now write

  <:value< current_timestamp () >>
