### PR TITLE
Camlp4 syntax: fix dependencies in META file

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -43,9 +43,10 @@ Library "syntax"
     Pa_bananas
   BuildDepends:
     camlp4
+  XMETAExtraLines:
+    requires(syntax) = "camlp4"
   XMETARequires:
-    macaque,
-    camlp4
+    macaque
   XMETAType: syntax
   XMETADescription:
     Syntax extension: Comprehension syntax for composable SQL statements


### PR DESCRIPTION
We don't want to load `macaque.cma` and its dependencies in the preprocessor.
This does not work with OCaml 4.08 since this loads a second time the `Unix` module which is already included in the `camlp4` binary